### PR TITLE
base:get_sdk_version_path: Fix handling of `` for missing SDK

### DIFF
--- a/modules/base.sh.in
+++ b/modules/base.sh.in
@@ -45,10 +45,8 @@ get_sdk_version_path () {
 # input: an SDK version (numbers only)
 # output: SDK_PATH and SDK_VERSION
 # codes: 0 if successfully set, 1 if SDK doesn't exist
-	SDK_PATH=`xcodebuild -version -sdk macosx${sdk_test_ver} Path 2>/dev/null`
-	if [[ $? -eq 0 ]]; then
-		# don't export SDK_PATH above because that affects what $? belongs to
-		export SDK_PATH
+	if xcodebuild -version -sdk macosx${sdk_test_ver} >/dev/null 2>&1; then
+		export SDK_PATH=`xcodebuild -version -sdk macosx${sdk_test_ver} Path 2>/dev/null`
 		export SDK_VERSION=`xcodebuild -version -sdk macosx${sdk_test_ver} SDKVersion 2>/dev/null`
 		return 0
 	else

--- a/modules/base.sh.in
+++ b/modules/base.sh.in
@@ -147,12 +147,7 @@ if [ -x /usr/bin/xcodebuild ] && [ -x /usr/bin/xcode-select ]; then
 		26)
 			# Xcode 16 can have any of the 26.2 - 26.0 SDKs. So walk from high to low until we find one.
 			for sdk_test_ver in 26.2 26.1 26.0; do
-				get_sdk_version_path $sdk_test_ver
-				if [[ $? -eq 0 ]]; then
-					break
-				else
-					continue
-				fi
+				get_sdk_version_path $sdk_test_ver && break
 			done
 			;;
 		*)


### PR DESCRIPTION
When `command` fails, the whole base.sh aborts rather than simply saving the subshell's exit-code and continuing. Redo the logic to test for success of the command, then iff success read its outputs.